### PR TITLE
Update str comparison and add options for output dir and disable header output

### DIFF
--- a/dtm2text.py
+++ b/dtm2text.py
@@ -85,7 +85,7 @@ def text2dtm(argv=None):
     with open(header_path, mode='rb') as bin_header_file:
         movie_data.write(bin_header_file.read())
 
-    with open(input_path, mode='r') if input_path is not '-' else sys.stdin as text_input_file:
+    with open(input_path, mode='r') if input_path != '-' else sys.stdin as text_input_file:
         for text_input in text_input_file:
             byte_input = byte_input_from_text(text_input)
             if byte_input:


### PR DESCRIPTION
Just a couple of minor updates:
- Updates line 88 `if input_path is not '-'` to use updated `if input_path != '-'`. This clears the `SyntaxWarning` in newer versions of Python.
- Adds optional arguments when converting DTM to TXT:
  - `-o DIR` or `--output DIR` for setting an output directory manually.
  - `--no-header` for disabling output of header file.